### PR TITLE
コピーボタン追加

### DIFF
--- a/components/shareButtons.vue
+++ b/components/shareButtons.vue
@@ -34,12 +34,37 @@
       class="share-link share-link-line"
       ><i class="fab fa-line"></i> 共有する
     </a>
+    <span
+      target="_blank"
+      class="share-link share-link-copy copy"
+      @click="copy(text + '\n https://yobikake.com/' + url)"
+      ><i class="far fa-copy"></i> URLと文章をコピー
+    </span>
+    <div id="copiedDialog" style="display: none;">
+      コピーしました！
+    </div>
   </div>
 </template>
 
 <script>
 export default {
-  props: ['url', 'text']
+  props: ['url', 'text'],
+  methods: {
+    copy(msg) {
+      const copyText = msg
+      navigator.clipboard.writeText(copyText)
+      const dialog = document.getElementById('copiedDialog')
+      dialog.style.display = 'block'
+      setTimeout(function() {
+        document.getElementById('copiedDialog').classList.add('huwaClass')
+        setTimeout(function() {
+          document.getElementById('copiedDialog').style.display = 'none'
+          document.getElementById('copiedDialog').style.opacity = 1
+          document.getElementById('copiedDialog').classList.remove('huwaClass')
+        }, 400)
+      }, 2000)
+    }
+  }
 }
 </script>
 
@@ -72,5 +97,34 @@ export default {
 }
 .share-link-line {
   background-color: #00bb00;
+}
+.share-link-copy {
+  background-color: #777777;
+  cursor: pointer;
+}
+#copiedDialog {
+  background-color: rgba(80, 80, 80, 0.8);
+  text-align: center;
+  padding: 6px;
+  color: #fff;
+  border-radius: 4px;
+  margin: auto;
+  top: 12vh;
+  right: 24px;
+  left: 24px;
+  position: fixed;
+}
+.huwaClass {
+  animation: huwa 0.4s ease alternate;
+}
+@keyframes huwa {
+  0% {
+    opacity: 1;
+    display: block;
+  }
+  100% {
+    opacity: 0;
+    display: block;
+  }
 }
 </style>

--- a/components/shareButtons.vue
+++ b/components/shareButtons.vue
@@ -35,7 +35,7 @@
 export default {
   props: ['url', 'text'],
   data: () => ({
-    copyLabel: 'URLをコピーする'
+    copyLabel: 'コピーする'
   }),
   methods: {
     copy(msg) {
@@ -44,7 +44,7 @@ export default {
       this.copyLabel = 'コピーしました！'
       setTimeout(
         function() {
-          this.copyLabel = 'URLをコピーする'
+          this.copyLabel = 'コピーする'
         }.bind(this),
         2000
       )

--- a/components/shareButtons.vue
+++ b/components/shareButtons.vue
@@ -38,31 +38,28 @@
       target="_blank"
       class="share-link share-link-copy copy"
       @click="copy(text + '\n https://yobikake.com/' + url)"
-      ><i class="far fa-copy"></i> URLと文章をコピー
+      ><i class="far fa-copy"></i>{{ copyLabel }}
     </span>
-    <div id="copiedDialog" style="display: none;">
-      コピーしました！
-    </div>
   </div>
 </template>
 
 <script>
 export default {
   props: ['url', 'text'],
+  data: () => ({
+    copyLabel: 'URLをコピーする'
+  }),
   methods: {
     copy(msg) {
       const copyText = msg
       navigator.clipboard.writeText(copyText)
-      const dialog = document.getElementById('copiedDialog')
-      dialog.style.display = 'block'
-      setTimeout(function() {
-        document.getElementById('copiedDialog').classList.add('huwaClass')
-        setTimeout(function() {
-          document.getElementById('copiedDialog').style.display = 'none'
-          document.getElementById('copiedDialog').style.opacity = 1
-          document.getElementById('copiedDialog').classList.remove('huwaClass')
-        }, 400)
-      }, 2000)
+      this.copyLabel = 'コピーしました！'
+      setTimeout(
+        function() {
+          this.copyLabel = 'URLをコピーする'
+        }.bind(this),
+        2000
+      )
     }
   }
 }
@@ -101,30 +98,5 @@ export default {
 .share-link-copy {
   background-color: #777777;
   cursor: pointer;
-}
-#copiedDialog {
-  background-color: rgba(80, 80, 80, 0.8);
-  text-align: center;
-  padding: 6px;
-  color: #fff;
-  border-radius: 4px;
-  margin: auto;
-  top: 12vh;
-  right: 24px;
-  left: 24px;
-  position: fixed;
-}
-.huwaClass {
-  animation: huwa 0.4s ease alternate;
-}
-@keyframes huwa {
-  0% {
-    opacity: 1;
-    display: block;
-  }
-  100% {
-    opacity: 0;
-    display: block;
-  }
 }
 </style>

--- a/components/shareButtons.vue
+++ b/components/shareButtons.vue
@@ -37,7 +37,7 @@
     <span
       target="_blank"
       class="share-link share-link-copy copy"
-      @click="copy(text + '\n https://yobikake.com/' + url)"
+      @click="copy('https://yobikake.com/' + url)"
       ><i class="far fa-copy"></i>{{ copyLabel }}
     </span>
   </div>

--- a/components/shareButtons.vue
+++ b/components/shareButtons.vue
@@ -81,7 +81,7 @@ export default {
   background-color: #3b5998;
 }
 .share-link-copy {
-  background-color: #777777;
+  background-color: #41b784;
   cursor: pointer;
 }
 </style>

--- a/components/shareButtons.vue
+++ b/components/shareButtons.vue
@@ -22,18 +22,6 @@
       class="share-link share-link-fb"
       ><i class="fab fa-facebook"></i> シェアする
     </a>
-    <a
-      :href="
-        'https://social-plugins.line.me/lineit/share?url=https://yobikake.com/' +
-          url +
-          '&text=' +
-          encodeURIComponent(text) +
-          '%0A'
-      "
-      target="_blank"
-      class="share-link share-link-line"
-      ><i class="fab fa-line"></i> 共有する
-    </a>
     <span
       target="_blank"
       class="share-link share-link-copy copy"
@@ -91,9 +79,6 @@ export default {
 }
 .share-link-fb {
   background-color: #3b5998;
-}
-.share-link-line {
-  background-color: #00bb00;
 }
 .share-link-copy {
   background-color: #777777;


### PR DESCRIPTION
コピーされる文言例
```
うちで過ごそう！みんなのために🏠
 #うちで過ごそう #stayhome #Yobikake
 https://yobikake.com/stayhome
```
ダイアログのふわっと非表示は、割と力技ですが今の所は問題を確認できていないので大丈夫だと思います。

LINEボタン撤去についてはまだ触れていません。ひとまず追加まで。